### PR TITLE
Add handlers to implement stats subcommand

### DIFF
--- a/lib/funcs.pm
+++ b/lib/funcs.pm
@@ -361,7 +361,7 @@ sub writeconfig {
 # Round numbers to any precision
 sub round {
 	my $x = shift;
-	my $pow10 = shift;
+	my $pow10 = shift || 0;
 	my $a = 10 ** $pow10;
 	return int(($x * $a) + 0.5) / $a
 }

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -18,7 +18,7 @@ our @EXPORT = qw(
 	film_add film_load film_archive film_develop film_tag film_locate
 	camera_add camera_displaylens camera_sell camera_repair camera_addbodytype camera_stats
 	mount_add mount_view mount_adapt
-	negative_add negative_bulkadd
+	negative_add negative_bulkadd negative_stats
 	lens_add lens_sell lens_repair lens_stats
 	print_add print_tone print_sell print_order print_fulfil print_archive print_locate
 	paperstock_add
@@ -379,6 +379,15 @@ sub negative_bulkadd {
 	}
 
 	print "Inserted $num negatives into film #$data{'film_id'}\n";
+}
+
+sub negative_stats {
+	my $db = shift;
+	my $film_id = prompt('', 'Film ID to print from', 'integer');
+	my $frame = &listchoices($db, 'Frame to print from', "select frame as id, description as opt from NEGATIVE where film_id=$film_id", 'text');
+	my $neg_id = &lookupval($db, "select lookupneg('$film_id', '$frame')");
+	my $noprints = &lookupval($db, "select count(*) from PRINT where negative_id=$neg_id");
+	print "\tThis negative has been printed $noprints times\n";
 }
 
 sub lens_add {

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -295,6 +295,8 @@ sub camera_repair {
 sub camera_stats {
 	my $db = shift;
 	my $camera_id = &listchoices($db, 'camera', "select camera_id as id, concat( manufacturer, ' ',model) as opt from CAMERA, MANUFACTURER where own=1 and CAMERA.manufacturer_id=MANUFACTURER.manufacturer_id order by opt");
+	my $camera = &lookupval($db, "select concat( manufacturer, ' ',model) as opt from CAMERA, MANUFACTURER where CAMERA.manufacturer_id=MANUFACTURER.manufacturer_id and camera_id=$camera_id");
+	print "\tShowing statistics for $camera\n";
 	my $total_shots_with_cam = &lookupval($db, "select count(*) from NEGATIVE, FILM where NEGATIVE.film_id=FILM.film_id and camera_id=$camera_id");
 	my $total_shots = &lookupval($db, "select count(*) from NEGATIVE");
 	if ($total_shots > 0) {
@@ -470,6 +472,8 @@ sub lens_repair {
 sub lens_stats {
 	my $db = shift;
 	my $lens_id = &listchoices($db, 'lens', "select lens_id as id, concat( manufacturer, ' ',model) as opt from LENS, MANUFACTURER where own=1 and fixed_mount=0 and LENS.manufacturer_id=MANUFACTURER.manufacturer_id order by opt");
+	my $lens = &lookupval($db, "select concat( manufacturer, ' ',model) as opt from LENS, MANUFACTURER where LENS.manufacturer_id=MANUFACTURER.manufacturer_id and lens_id=$lens_id");
+	print "\tShowing statistics for $lens\n";
 	my $total_shots_with_lens = &lookupval($db, "select count(*) from NEGATIVE where lens_id=$lens_id");
 	my $total_shots = &lookupval($db, "select count(*) from NEGATIVE");
 	if ($total_shots > 0) {

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -16,7 +16,7 @@ use tagger;
 
 our @EXPORT = qw(
 	film_add film_load film_archive film_develop film_tag film_locate
-	camera_add camera_displaylens camera_sell camera_repair camera_addbodytype
+	camera_add camera_displaylens camera_sell camera_repair camera_addbodytype camera_stats
 	mount_add mount_view mount_adapt
 	negative_add negative_bulkadd
 	lens_add lens_sell lens_repair lens_stats
@@ -290,6 +290,17 @@ sub camera_repair {
 	$data{'description'} = prompt('', 'Longer description of repair', 'text');
 	my $repair_id = &newrecord($db, \%data, 'REPAIR');
 	return $repair_id;
+}
+
+sub camera_stats {
+	my $db = shift;
+	my $camera_id = &listchoices($db, 'camera', "select camera_id as id, concat( manufacturer, ' ',model) as opt from CAMERA, MANUFACTURER where own=1 and CAMERA.manufacturer_id=MANUFACTURER.manufacturer_id order by opt");
+	my $total_shots_with_cam = &lookupval($db, "select count(*) from NEGATIVE, FILM where NEGATIVE.film_id=FILM.film_id and camera_id=$camera_id");
+	my $total_shots = &lookupval($db, "select count(*) from NEGATIVE");
+	if ($total_shots > 0) {
+		my $percentage = round(100 * $total_shots_with_cam / $total_shots);
+		print "\tThis camera has been used to take $total_shots_with_cam frames, which is ${percentage}% of the frames in your collection\n";
+	}
 }
 
 sub negative_add {

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -487,7 +487,7 @@ sub lens_stats {
 		my $minf = &lookupval($db, "select min_focal_length from LENS where lens_id=$lens_id");
 		my $maxf = &lookupval($db, "select max_focal_length from LENS where lens_id=$lens_id");
 		my $meanf = &lookupval($db, "select avg(focal_length) from NEGATIVE where lens_id=$lens_id");
-		print "\tThis is a zoom lens with a range of ${minf}-${maxf}mm, but the average focal length you used it ${meanf}mm\n";
+		print "\tThis is a zoom lens with a range of ${minf}-${maxf}mm, but the average focal length you used is ${meanf}mm\n";
 	}
 }
 

--- a/photodb
+++ b/photodb
@@ -37,7 +37,8 @@ my %handlers = (
 	},
 	negative => {
 		'add'      => { 'handler' => \&negative_add,     'desc' => 'Add a new negative to the database as part of a film' },
-		'bulk-add' => { 'handler' => \&negative_bulkadd, 'desc' => 'Bulk add multiple negatives to the database as part of a film' }
+		'bulk-add' => { 'handler' => \&negative_bulkadd, 'desc' => 'Bulk add multiple negatives to the database as part of a film' },
+		'stats'    => { 'handler' => \&negative_stats,   'desc' => 'Show statistics about a negative' },
 	},
 	mount => {
 		'add'   => { 'handler' => \&mount_add,   'desc' => 'Add a new lens mount to the database' },

--- a/photodb
+++ b/photodb
@@ -32,7 +32,8 @@ my %handlers = (
 		'display-lens' => { 'handler' => \&camera_displaylens, 'desc' => 'Associate a camera with a lens for display purposes' },
 		'show-lenses'  => { 'handler' => \&notimplemented,     'desc' => 'Not yet implemented' },
 		'sell'         => { 'handler' => \&camera_sell,        'desc' => 'Sell a camera' },
-		'repair'       => { 'handler' => \&camera_repair,      'desc' => 'Repair a camera' }
+		'repair'       => { 'handler' => \&camera_repair,      'desc' => 'Repair a camera' },
+		'stats'        => { 'handler' => \&camera_stats,       'desc' => 'Show statistics about a camera' },
 	},
 	negative => {
 		'add'      => { 'handler' => \&negative_add,     'desc' => 'Add a new negative to the database as part of a film' },

--- a/photodb
+++ b/photodb
@@ -45,7 +45,8 @@ my %handlers = (
 	lens => {
 		'add'    => { 'handler' => \&lens_add,    'desc' => 'Add a new lens to the database' },
 		'sell'   => { 'handler' => \&lens_sell,   'desc' => 'Sell a lens' },
-		'repair' => { 'handler' => \&lens_repair, 'desc' => 'Repair a lens' }
+		'repair' => { 'handler' => \&lens_repair, 'desc' => 'Repair a lens' },
+		'stats'  => { 'handler' => \&lens_stats,  'desc' => 'Show statistics about a lens' }
 	},
 	print => {
 		'add'     => { 'handler' => \&print_add,     'desc' => 'Add a new print that has been made from a negative' },


### PR DESCRIPTION
Add handlers to implement `stats` subcommand. Currently this is pretty trivial and only works for `camera`, `lens`, and `negative` but the structure is now there to build on.

Fixes #7 