### PR TITLE
Rewrite long queries as views

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,8 +119,8 @@ Fulfil an order for a print
 Add a print to a physical archive
 ### `print locate`
 Locate a print in an archive
-### `print reprint`
-Show details for making another print the same
+### `print info`
+Show details about a print
 ### `print exhibit`
 Exhibit a print at an exhibition
 ### `print label`

--- a/lib/commands.pm
+++ b/lib/commands.pm
@@ -73,7 +73,7 @@ our %handlers = (
 		'fulfil'   => { 'handler' => \&print_fulfil,   'desc' => 'Fulfil an order for a print' },
 		'archive'  => { 'handler' => \&print_archive,  'desc' => 'Add a print to a physical archive' },
 		'locate'   => { 'handler' => \&print_locate,   'desc' => 'Locate a print in an archive' },
-		'reprint'  => { 'handler' => \&print_reprint,  'desc' => 'Show details for making another print the same' },
+		'info'     => { 'handler' => \&print_info,     'desc' => 'Show details about a print' },
 		'exhibit'  => { 'handler' => \&print_exhibit,  'desc' => 'Exhibit a print in an exhibition' },
 		'label'    => { 'handler' => \&print_label,    'desc' => 'Generate text to label a print' },
 		'worklist' => { 'handler' => \&print_worklist, 'desc' => 'Display print todo list' },

--- a/lib/funcs.pm
+++ b/lib/funcs.pm
@@ -346,6 +346,7 @@ sub printlist {
 	my $table = $href->{table};
 	my $cols = $href->{cols} // ('id, opt');
 	my $where = $href->{where} // {};
+	my $order = $href->{order};
 
 	print "Now showing $msg\n";
 
@@ -356,7 +357,7 @@ sub printlist {
 	} elsif ($table && $cols && $where) {
 		# Use SQL::Abstract
 		my $sql = SQL::Abstract->new;
-		my($stmt, @bind) = $sql->select($table, $cols, $where);
+		my($stmt, @bind) = $sql->select($table, $cols, $where, $order);
 		$sth = $db->prepare($stmt);
 		$rows = $sth->execute(@bind);
 	} else {

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -348,7 +348,7 @@ sub camera_edit {
 		$data{x_sync} = &prompt({prompt=>'What\'s the X-sync speed?', type=>'text', default=>$$existing{x_sync}});
 		$data{flash_metering} = &listchoices({db=>$db, table=>'choose_flash_protocol', inserthandler=>\&flashprotocol_add, default=>$$existing{flash_metering}});
 	}
-	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'CONDITION', default=>$$existing{condition_id}});
+	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'`CONDITION`', default=>$$existing{condition_id}});
 	$data{oem_case} = &prompt({prompt=>'Do you have the original case for this camera?', type=>'boolean', default=>$$existing{oem_case}});
 	$data{dof_preview} = &prompt({prompt=>'Does this camera have a depth-of-field preview feature?', type=>'boolean', default=>$$existing{dof_preview}});
 	$data{tripod} = &prompt({prompt=>'Does this camera have a tripod bush?', type=>'boolean', default=>$$existing{tripod}});
@@ -688,7 +688,7 @@ sub lens_add {
 	$data{rectilinear} = &prompt({default=>'yes', prompt=>'Is this a rectilinear lens?', type=>'boolean'});
 	$data{length} = &prompt({prompt=>'How long is this lens? (mm)', type=>'integer'});
 	$data{diameter} = &prompt({prompt=>'How wide is this lens? (mm)', type=>'integer'});
-	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'CONDITION'});
+	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'`CONDITION`'});
 	$data{image_circle} = &prompt({prompt=>'What is the diameter of the image circle?', type=>'integer'});
 	$data{formula} = &prompt({prompt=>'Does this lens have a named optical formula?'});
 	$data{shutter_model} = &prompt({prompt=>'What shutter does this lens incorporate?'});
@@ -750,7 +750,7 @@ sub lens_edit {
 	$data{rectilinear} = &prompt({prompt=>'Is this a rectilinear lens?', type=>'boolean', default=>$$existing{rectilinear}});
 	$data{length} = &prompt({prompt=>'How long is this lens? (mm)', type=>'integer', default=>$$existing{length}});
 	$data{diameter} = &prompt({prompt=>'How wide is this lens? (mm)', type=>'integer', default=>$$existing{diameter}});
-	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'CONDITION', default=>$$existing{condition_id}});
+	$data{condition_id} = &listchoices({db=>$db, keyword=>'condition', cols=>['condition_id as id', 'name as opt'], table=>'`CONDITION`', default=>$$existing{condition_id}});
 	$data{image_circle} = &prompt({prompt=>'What is the diameter of the image circle?', type=>'integer', default=>$$existing{image_circle}});
 	$data{formula} = &prompt({prompt=>'Does this lens have a named optical formula?', default=>$$existing{formula}});
 	$data{shutter_model} = &prompt({prompt=>'What shutter does this lens incorporate?', default=>$$existing{shutter_model}});

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -556,7 +556,7 @@ sub negative_add {
 	$data{aperture} = &prompt({prompt=>'Aperture', type=>'decimal'});
 	my $filter_dia = 0;
 	if ($data{lens_id}) {
-		$filter_dia = &lookupval($db, "select if(filter_thread, filter_thread, 0) from LENS where lens_id=$data{lens_id}");
+		$filter_dia = &lookupval({db=>$db, query=>"select if(filter_thread, filter_thread, 0) from LENS where lens_id=$data{lens_id}");
 	}
 	$data{filter_id} = &listchoices({db=>$db, table=>'choose_filter', where=>{'thread'=>{'>=', $filter_dia}}, inserthandler=>\&filter_add, skipok=>1, autodefault=>0});
 	$data{teleconverter_id} = &listchoices({db=>$db, keyword=>'teleconverter', table=>'choose_teleconverter_by_film', where=>{film_id=>$data{film_id}}, inserthandler=>\&teleconverter_add, skipok=>1, autodefault=>0});

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -26,7 +26,7 @@ our @EXPORT = qw(
 	mount_add mount_view mount_adapt
 	negative_add negative_bulkadd negative_stats negative_prints
 	lens_add lens_sell lens_repair lens_stats lens_accessory lens_info lens_edit
-	print_add print_tone print_sell print_order print_fulfil print_archive print_locate print_reprint print_exhibit print_label print_worklist
+	print_add print_tone print_sell print_order print_fulfil print_archive print_locate print_info print_exhibit print_label print_worklist
 	paperstock_add
 	developer_add
 	toner_add
@@ -955,9 +955,9 @@ sub print_locate {
 	exit;
 }
 
-sub print_reprint {
+sub print_info {
 	my $db = shift;
-	my $print_id = &prompt({prompt=>'Which print do you want to reprint?', type=>'integer'});
+	my $print_id = &prompt({prompt=>'Which print do you want info on?', type=>'integer'});
 	my $data = &lookupcol({db=>$db, table=>'print_info', where=>{Print=>$print_id}});
 	print Dump($data);
 }

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -141,7 +141,7 @@ sub film_locate {
 	my $film_id = shift || &prompt({prompt=>'Which film do you want to locate?', type=>'integer'});
 
 	if (my $archiveid = &lookupval({db=>$db, col=>'archive_id', table=>'FILM', where=>{film_id=>$film_id}})) {
-		my $archive = &lookupval({db=>$db, col=>"select concat(name, ' (', location, ')') as archive", table=>'ARCHIVE', where=>{archive_id=> $archiveid}});
+		my $archive = &lookupval({db=>$db, col=>"concat(name, ' (', location, ')') as archive", table=>'ARCHIVE', where=>{archive_id=> $archiveid}});
 		print "Film #${film_id} is in $archive\n";
 	} else {
 		print "The location of film #${film_id} is unknown\n";
@@ -495,7 +495,7 @@ sub camera_choose {
 	$where{time} = &prompt({prompt=>'Do you need Time (T) shutter speed?', type=>'boolean'});
 	$where{fixed_mount} = &prompt({prompt=>'Do you need a camera with an interchangeable lens?', type=>'boolean'});
 	if ($where{fixed_mount} && $where{fixed_mount} != 1) {
-		$where{mount_id} = &listchoices({db=>$db, cols=>['select mount_id as id', 'mount as opt'], table=>'MOUNT', where=>{'purpose'=>'Camera'}});
+		$where{mount_id} = &listchoices({db=>$db, cols=>['mount_id as id', 'mount as opt'], table=>'MOUNT', where=>{'purpose'=>'Camera'}});
 	}
 	$where{focus_type_id} = &listchoices({db=>$db, cols=>['focus_type_id as id', 'focus_type as opt'], table=>'FOCUS_TYPE', 'integer'});
 	$where{metering} = &prompt({prompt=>'Do you need a camera with metering?', type=>'boolean'});
@@ -1420,7 +1420,7 @@ sub projector_add {
 	my %data;
 	$data{manufacturer_id} = &choose_manufacturer({db=>$db});
 	$data{model} = &prompt({prompt=>'What is the model of this projector?'});
-	$data{mount_id} = &listchoices({db=>$db, cols=>['select mount_id as id', 'mount as opt'], table=>'MOUNT', where=>{'purpose'=>'Projector'}, inserthandler=>\&mount_add});
+	$data{mount_id} = &listchoices({db=>$db, cols=>['mount_id as id', 'mount as opt'], table=>'MOUNT', where=>{'purpose'=>'Projector'}, inserthandler=>\&mount_add});
 	$data{negative_size_id} = &listchoices({db=>$db, cols=>['negative_size_id as id', 'negative_size as opt'], table=>'NEGATIVE_SIZE', inserthandler=>\&negativesize_add});
 	$data{own} = 1;
 	$data{cine} = &prompt({prompt=>'Is this a cine/movie projector?', type=>'boolean'});

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -970,7 +970,7 @@ sub print_reprint {
 	my $enlarger = &lookupval({db=>$db, query=>"select concat(manufacturer, ' ', enlarger) as enlarger from PRINT, ENLARGER, MANUFACTURER where print_id=$print_id and PRINT.enlarger_id=ENLARGER.enlarger_id and ENLARGER.manufacturer_id = MANUFACTURER.manufacturer_id"});
 	my $lens = &lookupval({db=>$db, query=>"select concat(manufacturer, ' ', model) as lens from PRINT, LENS, MANUFACTURER where print_id=$print_id and PRINT.lens_id=LENS.lens_id and LENS.manufacturer_id = MANUFACTURER.manufacturer_id"});
 	print "\tIt was made with the $enlarger enlarger and $lens lens\n";
-	if (&lookupval({db=>$db, query=>"select ENLARGER.lost from PRINT, ENLARGER where print_id=$print_id and PRINT.enlarger_id=ENLARGER.enlarger_id"})) {
+	if (&lookupval({db=>$db, col=>'ENLARGER.lost', table=>'PRINT join ENLARGER on PRINT.enlarger_id=ENLARGER.enlarger_id', where=>{print_id=>$print_id}})) {
 		print "\tYou no longer own the $enlarger, so the exposure information may be useless!\n";
 	}
 

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -1075,10 +1075,10 @@ sub mount_add {
 sub mount_view {
 	my $db = shift;
 	my $mountid = &listchoices({db=>$db, cols=>['mount_id as id', 'mount as opt'], table=>'MOUNT'});
-	my $mountname = &lookupval({db=>$db, col=>'mount', table=>'MOUNT', where=>{mount_id=>${mountid}}});
-	print "Showing data for $mountname mount\n";
-	&printlist({db=>$db, msg=>"cameras with $mountname mount", query=>"select C.camera_id as id, concat(M.manufacturer, ' ', C.model) as opt from CAMERA as C, MANUFACTURER as M where C.manufacturer_id=M.manufacturer_id and own=1 and mount_id=$mountid order by opt"});
-	&printlist({db=>$db, msg=>"lenses with $mountname mount", query=>"select lens_id as id, concat(manufacturer, ' ', model) as opt from LENS, MANUFACTURER where mount_id=$mountid and LENS.manufacturer_id=MANUFACTURER.manufacturer_id and own=1 order by opt"});
+	my $mount = &lookupval({db=>$db, col=>'mount', table=>'MOUNT', where=>{mount_id=>${mountid}}});
+	print "Showing data for $mount mount\n";
+	&printlist({db=>$db, msg=>"cameras with $mount mount", cols=>"camera_id as id, concat(manufacturer, ' ', model) as opt", table=>'CAMERA join MANUFACTURER on CAMERA.manufacturer_id=MANUFACTURER.manufacturer_id', where=>{own=>1, mount_id=>$mountid}, order=>'opt'});
+	&printlist({db=>$db, msg=>"lenses with $mount mount", cols=>"lens_id as id, concat(manufacturer, ' ', model) as opt", table=>'LENS join MANUFACTURER on LENS.manufacturer_id=MANUFACTURER.manufacturer_id', where=>{mount_id=>$mountid, own=>1}, order=>'opt'});
 }
 
 sub toner_add {

--- a/lib/handlers.pm
+++ b/lib/handlers.pm
@@ -556,7 +556,7 @@ sub negative_add {
 	$data{aperture} = &prompt({prompt=>'Aperture', type=>'decimal'});
 	my $filter_dia = 0;
 	if ($data{lens_id}) {
-		$filter_dia = &lookupval({db=>$db, query=>"select if(filter_thread, filter_thread, 0) from LENS where lens_id=$data{lens_id}");
+		$filter_dia = &lookupval({db=>$db, query=>"select if(filter_thread, filter_thread, 0) from LENS where lens_id=$data{lens_id}"});
 	}
 	$data{filter_id} = &listchoices({db=>$db, table=>'choose_filter', where=>{'thread'=>{'>=', $filter_dia}}, inserthandler=>\&filter_add, skipok=>1, autodefault=>0});
 	$data{teleconverter_id} = &listchoices({db=>$db, keyword=>'teleconverter', table=>'choose_teleconverter_by_film', where=>{film_id=>$data{film_id}}, inserthandler=>\&teleconverter_add, skipok=>1, autodefault=>0});

--- a/schema/photography_print_info.sql
+++ b/schema/photography_print_info.sql
@@ -1,11 +1,21 @@
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `print_info` (
-  `print_id` tinyint NOT NULL,
-  `description` tinyint NOT NULL,
-  `print_date` tinyint NOT NULL,
-  `photo_date` tinyint NOT NULL,
-  `name` tinyint NOT NULL
+  `Negative` tinyint NOT NULL,
+  `Print` tinyint NOT NULL,
+  `Description` tinyint NOT NULL,
+  `size` tinyint NOT NULL,
+  `Exposure time` tinyint NOT NULL,
+  `Aperture` tinyint NOT NULL,
+  `Filtration grade` tinyint NOT NULL,
+  `Paper` tinyint NOT NULL,
+  `Enlarger` tinyint NOT NULL,
+  `Enlarger lens` tinyint NOT NULL,
+  `First toner` tinyint NOT NULL,
+  `Second toner` tinyint NOT NULL,
+  `Print date` tinyint NOT NULL,
+  `Photo date` tinyint NOT NULL,
+  `Photographer` tinyint NOT NULL
 ) ENGINE=MyISAM */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `print_info`*/;
@@ -17,7 +27,7 @@ SET character_set_client = @saved_cs_client;
 /*!50001 SET collation_connection      = utf8_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
 /*!50013 DEFINER=`jonathan`@`%` SQL SECURITY DEFINER */
-/*!50001 VIEW `print_info` AS select `PRINT`.`print_id` AS `print_id`,`NEGATIVE`.`description` AS `description`,date_format(`PRINT`.`date`,'%M %Y') AS `print_date`,date_format(`NEGATIVE`.`date`,'%M %Y') AS `photo_date`,`PERSON`.`name` AS `name` from ((`PRINT` join `NEGATIVE` on((`PRINT`.`negative_id` = `NEGATIVE`.`negative_id`))) left join `PERSON` on((`NEGATIVE`.`photographer_id` = `PERSON`.`person_id`))) */;
+/*!50001 VIEW `print_info` AS select concat(`NEGATIVE`.`film_id`,'/',`NEGATIVE`.`frame`) AS `Negative`,`PRINT`.`print_id` AS `Print`,`NEGATIVE`.`description` AS `Description`,concat(`PRINT`.`width`,'x',`PRINT`.`height`,'"') AS `size`,concat(`PRINT`.`exposure_time`,'s') AS `Exposure time`,concat('f/',`PRINT`.`aperture`) AS `Aperture`,`PRINT`.`filtration_grade` AS `Filtration grade`,concat(`PAPER_STOCK_MANUFACTURER`.`manufacturer`,' ',`PAPER_STOCK`.`name`) AS `Paper`,concat(`ENLARGER_MANUFACTURER`.`manufacturer`,' ',`ENLARGER`.`enlarger`) AS `Enlarger`,concat(`LENS_MANUFACTURER`.`manufacturer`,' ',`LENS`.`model`) AS `Enlarger lens`,concat(`FIRSTTONER_MANUFACTURER`.`manufacturer`,' ',`FIRSTTONER`.`toner`,if((`PRINT`.`toner_dilution` is not null),concat(' (',`PRINT`.`toner_dilution`,')'),''),if((`PRINT`.`toner_time` is not null),concat(' for ',`PRINT`.`toner_time`),'')) AS `First toner`,concat(`SECONDTONER_MANUFACTURER`.`manufacturer`,' ',`SECONDTONER`.`toner`,if((`PRINT`.`2nd_toner_dilution` is not null),concat(' (',`PRINT`.`2nd_toner_dilution`,')'),''),if((`PRINT`.`2nd_toner_time` is not null),concat(' for ',`PRINT`.`2nd_toner_time`),'')) AS `Second toner`,date_format(`PRINT`.`date`,'%M %Y') AS `Print date`,date_format(`NEGATIVE`.`date`,'%M %Y') AS `Photo date`,`PERSON`.`name` AS `Photographer` from ((((((((((((`PRINT` join `PAPER_STOCK` on((`PRINT`.`paper_stock_id` = `PAPER_STOCK`.`paper_stock_id`))) join `MANUFACTURER` `PAPER_STOCK_MANUFACTURER` on((`PAPER_STOCK`.`manufacturer_id` = `PAPER_STOCK_MANUFACTURER`.`manufacturer_id`))) left join `ENLARGER` on((`PRINT`.`enlarger_id` = `ENLARGER`.`enlarger_id`))) join `MANUFACTURER` `ENLARGER_MANUFACTURER` on((`ENLARGER`.`manufacturer_id` = `ENLARGER_MANUFACTURER`.`manufacturer_id`))) left join `LENS` on((`PRINT`.`lens_id` = `LENS`.`lens_id`))) join `MANUFACTURER` `LENS_MANUFACTURER` on((`LENS`.`manufacturer_id` = `LENS_MANUFACTURER`.`manufacturer_id`))) left join `TONER` `FIRSTTONER` on((`PRINT`.`toner_id` = `FIRSTTONER`.`toner_id`))) left join `MANUFACTURER` `FIRSTTONER_MANUFACTURER` on((`FIRSTTONER`.`manufacturer_id` = `FIRSTTONER_MANUFACTURER`.`manufacturer_id`))) left join `TONER` `SECONDTONER` on((`PRINT`.`2nd_toner_id` = `SECONDTONER`.`toner_id`))) left join `MANUFACTURER` `SECONDTONER_MANUFACTURER` on((`SECONDTONER`.`manufacturer_id` = `SECONDTONER_MANUFACTURER`.`manufacturer_id`))) left join `NEGATIVE` on((`PRINT`.`negative_id` = `NEGATIVE`.`negative_id`))) left join `PERSON` on((`NEGATIVE`.`photographer_id` = `PERSON`.`person_id`))) */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;


### PR DESCRIPTION
Rewrite long queries as views. Also rename `print reprint` to `print info.

Fixes #93 #81