### PR TITLE
Don't use global terminal handler

### DIFF
--- a/lib/App/PhotoDB.pm
+++ b/lib/App/PhotoDB.pm
@@ -277,7 +277,7 @@ sub main {
 	my $db = &db;
 
 	# Set up terminal
-	our $term = &term;
+	my $term = &term;
 
 	# Enter interactive prompt and loop until exited by user
 	while (1) {

--- a/lib/App/PhotoDB/funcs.pm
+++ b/lib/App/PhotoDB/funcs.pm
@@ -86,7 +86,9 @@ sub prompt {
 	$msg .= " [$default]" if $showdefault;
 	$msg .= "$char ";
 
-	my $term = $App::PhotoDB::term;
+	# Create terminal handler
+	my $term = &term;
+
 	my $rv;
 	# Repeatedly prompt user until we get a response of the correct type
 	do {


### PR DESCRIPTION
Part of #228 , and required to make it work on CentOS and Ubuntu, although oddly it works as-is on Fedora. Maybe that's just coincidental.