### PR TITLE
Rewrite DBD's scientific format string 0E0

### DIFF
--- a/lib/App/PhotoDB/funcs.pm
+++ b/lib/App/PhotoDB/funcs.pm
@@ -382,7 +382,7 @@ sub updaterecord {
 	# Execute query
 	my $sth = $db->prepare($stmt);
 	my $rows = $sth->execute(@bind);
-	$rows = 0 if ($rows eq  '0E0');
+	$rows = &unsci($rows);
 	print "Updated $rows rows\n" unless $silent;
 	&logger({db=>$db, type=>'EDIT', message=>"$table $rows rows"}) if $log;
 	return $rows;
@@ -455,7 +455,7 @@ sub deleterecord {
 	# Execute query
 	my $sth = $db->prepare($stmt);
 	my $rows = $sth->execute(@bind);
-	$rows = 0 if ($rows eq  '0E0');
+	$rows = &unsci($rows);
 	print "Deleted $rows rows\n" unless $silent;
 	&logger({db=>$db, type=>'DELETE', message=>"$table $rows rows"}) if $log;
 	return $rows;
@@ -800,7 +800,7 @@ sub printlist {
 		my($stmt, @bind) = $sql->select($table, $cols, $where, $order);
 		$sth = $db->prepare($stmt);
 		$rows = $sth->execute(@bind);
-		$rows = 0 if ($rows eq  '0E0');
+		$rows = &unsci($rows);
 	} else {
 		print "Must pass in table, cols, where\n";
 		return;
@@ -1072,8 +1072,7 @@ sub updatedata {
 	my $query = shift;	# Plain SQL query
 	my $sth = $db->prepare($query) or die "Couldn't prepare statement: " . $db->errstr;
 	my $rows = $sth->execute();
-	# DBD returns scientific 0E0 instead of 0
-	$rows = 0 if ($rows eq '0E0');
+	$rows = &unsci($rows);
 	return $rows;
 }
 
@@ -1728,9 +1727,10 @@ sub tag {
 	# Prepare and execute the SQL
 	my $sth = $db->prepare($stmt) or die "Couldn't prepare statement: " . $db->errstr;
 	my $rows = $sth->execute(@bind);
+	$rows - &unsci($rows);
 
 	# Get confirmation
-	if ($rows eq  '0E0') {
+	if ($rows == 0) {
 		print "No scans be will tagged\n";
 		return;
 	}

--- a/lib/App/PhotoDB/funcs.pm
+++ b/lib/App/PhotoDB/funcs.pm
@@ -25,7 +25,7 @@ use Term::ReadLine;
 use Term::ReadLine::Perl;
 use File::Basename;
 
-our @EXPORT_OK = qw(prompt db updaterecord deleterecord newrecord notimplemented nocommand nosubcommand listchoices lookupval lookuplist updatedata today validate ini printlist round pad lookupcol thin resolvenegid chooseneg annotatefilm keyword parselensmodel unsetdisplaylens welcome duration tag printbool hashdiff logger now choosescan basepath call untaint fsfiles dbfiles term);
+our @EXPORT_OK = qw(prompt db updaterecord deleterecord newrecord notimplemented nocommand nosubcommand listchoices lookupval lookuplist updatedata today validate ini printlist round pad lookupcol thin resolvenegid chooseneg annotatefilm keyword parselensmodel unsetdisplaylens welcome duration tag printbool hashdiff logger now choosescan basepath call untaint fsfiles dbfiles term unsci);
 
 =head2 prompt
 
@@ -2013,6 +2013,31 @@ sub dbfiles {
 	@dbfiles = grep {$_} @dbfiles;
 
 	return @dbfiles;
+}
+
+
+=head2 unsci
+
+DBD returns integer zero in scientific format as 0E0. This rewrites it.
+
+=head4 Usage
+
+    $int = &unsci($int);
+
+=head4 Arguments
+
+=item * C<$int> an integer returned by DBD
+
+=head4 Returns
+
+The same integer as passed in, except with string 0E0 rewritten as integer 0
+
+=cut
+
+sub unsci {
+	my $int = shift;
+	$int = 0 if ($int eq '0E0');
+	return $int;
 }
 
 # This ensures the lib loads smoothly


### PR DESCRIPTION
Use a new function to rewrite DBD's scientific format string `0E0` as integer `0`

Fixes #243 