### PR TITLE
Fix task run

### DIFF
--- a/lib/App/PhotoDB/handlers.pm
+++ b/lib/App/PhotoDB/handlers.pm
@@ -1628,7 +1628,7 @@ sub exhibition_info {
 sub run_task {
 	my $db = shift;
 
-	my @tasks = @photodb::queries::tasks;
+	my @tasks = @App::PhotoDB::queries::tasks;
 	for my $i (0 .. $#tasks) {
 		print "\t$i\t$tasks[$i]{desc}\n";
 	}
@@ -1646,7 +1646,7 @@ sub run_task {
 sub run_report {
 	my $db = shift;
 
-	my @reports = @photodb::queries::reports;
+	my @reports = @App::PhotoDB::queries::reports;
 	for my $i (0 .. $#reports) {
 		print "\t$i\t$reports[$i]{desc}\n";
 	}

--- a/lib/App/PhotoDB/handlers.pm
+++ b/lib/App/PhotoDB/handlers.pm
@@ -1629,6 +1629,11 @@ sub run_task {
 	my $db = shift;
 
 	my @tasks = @App::PhotoDB::queries::tasks;
+	if (scalar(@tasks) == 0) {
+		print "No tasks found\n";
+		return 0;
+	}
+
 	for my $i (0 .. $#tasks) {
 		print "\t$i\t$tasks[$i]{desc}\n";
 	}
@@ -1647,6 +1652,11 @@ sub run_report {
 	my $db = shift;
 
 	my @reports = @App::PhotoDB::queries::reports;
+	if (scalar(@reports) == 0) {
+		print "No reports found\n";
+		return 0;
+	}
+
 	for my $i (0 .. $#reports) {
 		print "\t$i\t$reports[$i]{desc}\n";
 	}


### PR DESCRIPTION
Fix namespacing when loading tasks and reports. Trap this error in future, too. Fixes #250 