### PR TITLE
Tweak schema to cope with long shutter speeds

### DIFF
--- a/migrations/004-shutter-precision.sql
+++ b/migrations/004-shutter-precision.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `SHUTTER_SPEED` CHANGE COLUMN `duration` `duration` DECIMAL(9,5) NULL DEFAULT NULL COMMENT 'Shutter speed in decimal notation, e.g. 0.04' ;
+UPDATE `SHUTTER_SPEED` set `duration`=`shutter_speed` where `duration` = 99.99999 and `shutter_speed` REGEXP '^[0-9]+$';


### PR DESCRIPTION
Add migration to tweak schema to cope with shutter speeds longer than 100s

Fixes #248 