### PR TITLE
Skip migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - mysql -e "create schema photodb; GRANT ALL PRIVILEGES ON photodb.* TO photodb@localhost IDENTIFIED BY 'photodb'"
   - mkdir -p ~/.photodb
   - echo -e "[database]\nuser=photodb\nschema=photodb\npass=photodb\nhost=localhost" > ~/.photodb/photodb.ini
+install: cpanm --quiet --installdeps --notest --skip-satisfied .
 jobs:
   include:
   - stage: test

--- a/README.pod
+++ b/README.pod
@@ -32,6 +32,10 @@ MySQL username
 
 MySQL password
 
+=item --skipmigrations
+
+If specified, PhotoDB will not attempt to run database migrations on startup
+
 =back
 
 =head1 DESCRIPTION

--- a/bin/photodb
+++ b/bin/photodb
@@ -12,6 +12,7 @@ GetOptions (\%args,
 	'schema|s=s',
 	'user|u=s',
 	'password|p=s',
+	'skipmigrations',
 );
 
 &App::PhotoDB::main(\%args);

--- a/lib/App/PhotoDB.pm
+++ b/lib/App/PhotoDB.pm
@@ -34,6 +34,10 @@ MySQL username
 
 MySQL password
 
+=item --skipmigrations
+
+If specified, PhotoDB will not attempt to run database migrations on startup
+
 =back
 
 =head1 DESCRIPTION

--- a/lib/App/PhotoDB/commands.pm
+++ b/lib/App/PhotoDB/commands.pm
@@ -706,10 +706,15 @@ Run a selection of maintenance tasks on the database
 
 Run a selection of reports on the database
 
+=head3 run migrations
+
+Run migrations to upgrade the database schema to the latest version
+
 =cut
 	$handlers{run} = {
-		'task'   => { 'handler' => \&run_task,   'desc' => 'Run a selection of maintenance tasks on the database' },
-		'report' => { 'handler' => \&run_report, 'desc' => 'Run a selection of reports on the database' },
+		'task'       => { 'handler' => \&run_task,       'desc' => 'Run a selection of maintenance tasks on the database' },
+		'report'     => { 'handler' => \&run_report,     'desc' => 'Run a selection of reports on the database' },
+		'migrations' => { 'handler' => \&run_migrations, 'desc' => 'Run migrations to upgrade the database schema to the latest version' },
 	};
 
 # This ensures the lib loads smoothly

--- a/lib/App/PhotoDB/handlers.pm
+++ b/lib/App/PhotoDB/handlers.pm
@@ -24,7 +24,7 @@ our @EXPORT_OK = qw(
 	paperstock_add
 	developer_add
 	toner_add
-	run_task run_report
+	run_task run_report run_migrations
 	filmstock_add
 	teleconverter_add
 	filter_add filter_adapt
@@ -1802,6 +1802,14 @@ sub run_report {
 	if (defined($action) && $choices[$action]->{view}) {
 		&tabulate({db=>$db, view=>$choices[$action]->{view}});
 	}
+	return;
+}
+
+# Run database migrations to upgrade the schema
+sub run_migrations {
+	my $href = shift;
+	my $db = $href->{db};
+	&runmigrations($db);
 	return;
 }
 

--- a/t/02-perlcritic.t
+++ b/t/02-perlcritic.t
@@ -1,6 +1,5 @@
 use strict;
 use warnings;
-use File::Spec;
 use Test::More;
 use English qw(-no_match_vars);
 
@@ -11,6 +10,5 @@ if ( $EVAL_ERROR ) {
    plan( skip_all => $msg );
 }
 
-my $rcfile = File::Spec->catfile( 't', 'perlcriticrc' );
-Test::Perl::Critic->import( -profile => $rcfile );
+Test::Perl::Critic->import( -severity => 4 );
 all_critic_ok();

--- a/t/03-migrations.t
+++ b/t/03-migrations.t
@@ -1,12 +1,11 @@
 use Test::Expect;
-use Test::More tests => 1;
+use Test::More tests => 3;
+
 expect_run(
-  command => ["bin/photodb -h localhost -s photodb -u photodb -p photodb"],
+  command => ["bin/photodb -h localhost -s photodb -u photodb -p photodb --skipmigrations"],
   prompt  => 'photodb> ',
   quit    => 'exit',
 );
-#expect_is('photodb> ');
-#expect("ping", "pong", "expect");
-#expect_send("ping", "expect_send");
-#expect_is("* Hi there, to testme", "expect_is");
-#expect_like(qr/Hi there, to testme/, "expect_like");
+
+expect_send("run migrations\n", "run migrations");
+expect_like(qr/Applied migration /, "applied migrations");


### PR DESCRIPTION
* Makes migrations skippable
* Add handler to run migrations manually
* Tests migrations more carefully
* Runs tests faster by using system perl modules if they exist

Fixes #281 